### PR TITLE
Add fallback capabilities to the dbcreate jobs (allows separate RDS instances from cloud-automation using external-secrets)

### DIFF
--- a/helm/common/templates/_db_setup_job.tpl
+++ b/helm/common/templates/_db_setup_job.tpl
@@ -62,7 +62,7 @@ spec:
             {{- else if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" .Chart.Name) }}
                 key: password
                 optional: false
             {{- else }}
@@ -72,7 +72,7 @@ spec:
             {{- if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" .Chart.Name) }}
                 key: username
                 optional: false
             {{- else }}
@@ -82,7 +82,7 @@ spec:
             {{- if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" .Chart.Name) }}
                 key: port
                 optional: false
             {{- else }}
@@ -94,7 +94,7 @@ spec:
             {{- else if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" .Chart.Name) }}
                 key: host
                 optional: false
             {{- else }}

--- a/helm/common/templates/_db_setup_job.tpl
+++ b/helm/common/templates/_db_setup_job.tpl
@@ -59,66 +59,42 @@ spec:
                 name: {{ .Release.Name }}-postgresql
                 key: postgres-password
                 optional: false
-            {{- else if .Values.externalSecrets.dbcreds }}
+            {{- else if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds }}
-                key: password
-                optional: false
-            {{- else if $.Values.global.postgres.externalSecret }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret }}
+                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
                 key: password
                 optional: false
             {{- else }}
             value:  {{ .Values.global.postgres.master.password | quote}}
             {{- end }}
           - name: PGUSER
-          {{- if .Values.externalSecrets.dbcreds }}
+            {{- if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds }}
+                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
                 key: username
                 optional: false
-          {{- else if $.Values.global.postgres.externalSecret }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret }}
-                key: username
-                optional: false
-          {{- else }}
+            {{- else }}
             value: {{ .Values.global.postgres.master.username | quote }}
-          {{- end }}
+            {{- end }}
           - name: PGPORT
-          {{- if .Values.externalSecrets.dbcreds }}
+            {{- if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds }}
+                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
                 key: port
                 optional: false
-          {{- else if $.Values.global.postgres.externalSecret }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret }}
-                key: port
-                optional: false
-          {{- else }}
+            {{- else }}
             value: {{ .Values.global.postgres.master.port | quote }}
-          {{- end }}
+            {{- end }}
           - name: PGHOST
             {{- if $.Values.global.dev }}
             value: "{{ .Release.Name }}-postgresql"
-            {{- else if .Values.externalSecrets.dbcreds }}
+            {{- else if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds }}
-                key: host
-                optional: false
-            {{- else if $.Values.global.postgres.externalSecret }}
-            valueFrom:
-              secretKeyRef:
-                name: {{ $.Values.global.postgres.externalSecret }}
+                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
                 key: host
                 optional: false
             {{- else }}

--- a/helm/common/templates/_db_setup_job.tpl
+++ b/helm/common/templates/_db_setup_job.tpl
@@ -59,6 +59,12 @@ spec:
                 name: {{ .Release.Name }}-postgresql
                 key: postgres-password
                 optional: false
+            {{- else if .Values.postgres.externalSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.postgres.externalSecret }}
+                key: password
+                optional: false
             {{- else if $.Values.global.postgres.externalSecret }}
             valueFrom:
               secretKeyRef:
@@ -69,7 +75,13 @@ spec:
             value:  {{ .Values.global.postgres.master.password | quote}}
             {{- end }}
           - name: PGUSER
-          {{- if $.Values.global.postgres.externalSecret }}
+          {{- if .Values.postgres.externalSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.postgres.externalSecret }}
+                key: username
+                optional: false
+          {{- else if $.Values.global.postgres.externalSecret }}
             valueFrom:
               secretKeyRef:
                 name: {{ $.Values.global.postgres.externalSecret }}
@@ -79,7 +91,13 @@ spec:
             value: {{ .Values.global.postgres.master.username | quote }}
           {{- end }}
           - name: PGPORT
-          {{- if $.Values.global.postgres.externalSecret }}
+          {{- if .Values.postgres.externalSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.postgres.externalSecret }}
+                key: port
+                optional: false
+          {{- else if $.Values.global.postgres.externalSecret }}
             valueFrom:
               secretKeyRef:
                 name: {{ $.Values.global.postgres.externalSecret }}
@@ -91,6 +109,12 @@ spec:
           - name: PGHOST
             {{- if $.Values.global.dev }}
             value: "{{ .Release.Name }}-postgresql"
+            {{- else if .Values.postgres.externalSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.postgres.externalSecret }}
+                key: host
+                optional: false
             {{- else if $.Values.global.postgres.externalSecret }}
             valueFrom:
               secretKeyRef:

--- a/helm/common/templates/_db_setup_job.tpl
+++ b/helm/common/templates/_db_setup_job.tpl
@@ -59,10 +59,10 @@ spec:
                 name: {{ .Release.Name }}-postgresql
                 key: postgres-password
                 optional: false
-            {{- else if .Values.postgres.externalSecret }}
+            {{- else if .Values.externalSecrets.dbcreds }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.externalSecret }}
+                name: {{ .Values.externalSecrets.dbcreds }}
                 key: password
                 optional: false
             {{- else if $.Values.global.postgres.externalSecret }}
@@ -75,10 +75,10 @@ spec:
             value:  {{ .Values.global.postgres.master.password | quote}}
             {{- end }}
           - name: PGUSER
-          {{- if .Values.postgres.externalSecret }}
+          {{- if .Values.externalSecrets.dbcreds }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.externalSecret }}
+                name: {{ .Values.externalSecrets.dbcreds }}
                 key: username
                 optional: false
           {{- else if $.Values.global.postgres.externalSecret }}
@@ -91,10 +91,10 @@ spec:
             value: {{ .Values.global.postgres.master.username | quote }}
           {{- end }}
           - name: PGPORT
-          {{- if .Values.postgres.externalSecret }}
+          {{- if .Values.externalSecrets.dbcreds }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.externalSecret }}
+                name: {{ .Values.externalSecrets.dbcreds }}
                 key: port
                 optional: false
           {{- else if $.Values.global.postgres.externalSecret }}
@@ -109,10 +109,10 @@ spec:
           - name: PGHOST
             {{- if $.Values.global.dev }}
             value: "{{ .Release.Name }}-postgresql"
-            {{- else if .Values.postgres.externalSecret }}
+            {{- else if .Values.externalSecrets.dbcreds }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.externalSecret }}
+                name: {{ .Values.externalSecrets.dbcreds }}
                 key: host
                 optional: false
             {{- else if $.Values.global.postgres.externalSecret }}

--- a/helm/common/templates/_db_setup_job.tpl
+++ b/helm/common/templates/_db_setup_job.tpl
@@ -59,30 +59,30 @@ spec:
                 name: {{ .Release.Name }}-postgresql
                 key: postgres-password
                 optional: false
-            {{- else if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
+            {{- else if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
                 key: password
                 optional: false
             {{- else }}
             value:  {{ .Values.global.postgres.master.password | quote}}
             {{- end }}
           - name: PGUSER
-            {{- if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
+            {{- if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
                 key: username
                 optional: false
             {{- else }}
             value: {{ .Values.global.postgres.master.username | quote }}
             {{- end }}
           - name: PGPORT
-            {{- if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
+            {{- if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
                 key: port
                 optional: false
             {{- else }}
@@ -91,10 +91,10 @@ spec:
           - name: PGHOST
             {{- if $.Values.global.dev }}
             value: "{{ .Release.Name }}-postgresql"
-            {{- else if or .Values.externalSecrets.dbcreds $.Values.global.postgres.externalSecret  }}
+            {{- else if $.Values.global.externalSecrets.deploy }}
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.externalSecrets.dbcreds | default $.Values.global.postgres.externalSecret }}
+                name: {{ $.Values.global.postgres.externalSecret | default (printf "%s-dbcreds" $.Chart.Name) }}
                 key: host
                 optional: false
             {{- else }}


### PR DESCRIPTION
Modify the _db_setup_job.tpl file to provide fallbacks when a user is deploying multiple database servers.  Previously, the external secret for the dbcreate jobs would only allow for references to `$.Values.global.postgres.externalSecret`.  Of course, a single value will not work for us since cloud-automation deploys 3 separate RDS instances to connect to.  This resolves that issue